### PR TITLE
Fix uninitialized constant BundledGem::Cli::Bundler (NameError)

### DIFF
--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -7,7 +7,7 @@ module BundledGem
     desc "list", "bundle list(without bundle install)"
     def list
       gemfilelock_content = File.read("./Gemfile.lock")
-      lockfile = Bundler::LockfileParser.new(gemfilelock_content)
+      lockfile = ::Bundler::LockfileParser.new(gemfilelock_content)
       lockfile.specs.each { |s| puts "#{s.name}, #{s.version}" }
     end
   end

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require "bundled_gem/version"
 
 module BundledGem


### PR DESCRIPTION
```
uninitialized constant BundledGem::Cli::Bundler (NameError)
```

## Result

```
$ bgem
Commands:
  bgem help [COMMAND]  # Describe available commands or one specific command
  bgem list            # bundle list(without bundle install)

$ bgem list
bundled_gems, 0.0.2
minitest, 5.12.2
rake, 13.0.0
thor, 0.20.3