### PR TITLE
Add install command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         ruby: [2.4.x, 2.5.x, 2.6.x]
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,3 +19,5 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec rake
         ./bin/bgem
+        ./bin/bgem list
+        ./bin/bgem install rake

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,6 @@ jobs:
         gem install bundler --force --no-document
         bundle install --jobs 4 --retry 3
         bundle exec rake
-        ./bin/bgem
-        ./bin/bgem list
-        ./bin/bgem install rake
+    - run: ./bin/bgem
+    - run: ./bin/bgem list
+    - run: ./bin/bgem install rake

--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -6,7 +6,8 @@ module BundledGem
   class Cli < Thor
     desc "install [BUNDLED_GEM]", "install [BUNDLED_GEM] from `Gemfile.lock`"
     def install(bundled_gem)
-      # TODO
+      reader = LockfileReader.new
+      puts "`#{bundled_gem}` is not listed in Gemfile.lock." unless reader.gem_listed?(bundled_gem)
     end
 
     desc "list", "bundle list without `bundle install`"

--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -11,7 +11,10 @@ module BundledGem
 
     desc "list", "bundle list without `bundle install`"
     def list
-      LockfileReader.new.lockfile_specs.each { |s| puts "#{s.name}, #{s.version}" }
+      puts "Gems included in `Gemfile.lock`:"
+      LockfileReader.new.lockfile_specs.each do |s| 
+        puts "  * #{s.name}, #{s.version}" 
+      end
     end
   end
 end

--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -4,7 +4,12 @@ require 'thor'
 
 module BundledGem
   class Cli < Thor
-    desc "list", "bundle list(without bundle install)"
+    desc "install [BUNDLED_GEM]", "install [BUNDLED_GEM] from `Gemfile.lock` without `bundle install`"
+    def install(bundled_gem)
+      # TODO
+    end
+
+    desc "list", "bundle list without `bundle install`"
     def list
       gemfilelock_content = File.read("./Gemfile.lock")
       lockfile = ::Bundler::LockfileParser.new(gemfilelock_content)

--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -4,16 +4,14 @@ require 'thor'
 
 module BundledGem
   class Cli < Thor
-    desc "install [BUNDLED_GEM]", "install [BUNDLED_GEM] from `Gemfile.lock` without `bundle install`"
+    desc "install [BUNDLED_GEM]", "install [BUNDLED_GEM] from `Gemfile.lock`"
     def install(bundled_gem)
       # TODO
     end
 
     desc "list", "bundle list without `bundle install`"
     def list
-      gemfilelock_content = File.read("./Gemfile.lock")
-      lockfile = ::Bundler::LockfileParser.new(gemfilelock_content)
-      lockfile.specs.each { |s| puts "#{s.name}, #{s.version}" }
+      LockfileReader.new.lockfile_specs.each { |s| puts "#{s.name}, #{s.version}" }
     end
   end
 end

--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -7,7 +7,12 @@ module BundledGem
     desc "install [BUNDLED_GEM]", "install [BUNDLED_GEM] from `Gemfile.lock`"
     def install(bundled_gem)
       reader = LockfileReader.new
-      puts "`#{bundled_gem}` is not listed in Gemfile.lock." unless reader.gem_listed?(bundled_gem)
+      if reader.gem_listed?(bundled_gem)
+        version = reader.get_version(bundled_gem)
+        system "gem install #{bundled_gem} --version #{version}"
+      else
+        abort "`#{bundled_gem}` is not listed in Gemfile.lock." 
+      end
     end
 
     desc "list", "bundle list without `bundle install`"

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -18,7 +18,7 @@ module BundledGem
 
     # Check gem is listed in `Gemfile.lock`
     def gem_listed?(gem)
-      lockfile_specs.map(:name).include? gem
+      lockfile_specs.map(&:name).include? gem
     end
 
     private

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -4,6 +4,17 @@ require 'bundler'
 require "bundled_gem/version"
 
 module BundledGem
-  class Error < StandardError; end
-  # Your code goes here...
+  class LockfileReader
+    LOCKFILE = "Gemfile.lock"
+
+    def initialize(lockfile: LOCKFILE)
+      @lockfile = lockfile
+    end
+
+    def lockfile_specs
+      lockfile_content = File.read(@lockfile)
+      lockfile = ::Bundler::LockfileParser.new(lockfile_content)
+      lockfile.specs
+    end
+  end
 end

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -16,6 +16,11 @@ module BundledGem
       lockfile.specs
     end
 
+    # Get version info from `Gemfile.lock`
+    def get_version(gem)
+      lockfile_specs.find{ |s| s.name == "rake"}.version
+    end
+
     # Check gem is listed in `Gemfile.lock`
     def gem_listed?(gem)
       lockfile_specs.map(&:name).include? gem

--- a/lib/bundled_gems.rb
+++ b/lib/bundled_gems.rb
@@ -8,13 +8,23 @@ module BundledGem
     LOCKFILE = "Gemfile.lock"
 
     def initialize(lockfile: LOCKFILE)
-      @lockfile = lockfile
+      @lockfile_content = File.read(lockfile)
     end
 
+    # Parse `Gemfile.lock` and Retrieve specs
     def lockfile_specs
-      lockfile_content = File.read(@lockfile)
-      lockfile = ::Bundler::LockfileParser.new(lockfile_content)
       lockfile.specs
+    end
+
+    # Check gem is listed in `Gemfile.lock`
+    def gem_listed?(gem)
+      lockfile_specs.map(:name).include? gem
+    end
+
+    private
+
+    def lockfile
+      @lockfile ||= ::Bundler::LockfileParser.new(@lockfile_content)
     end
   end
 end


### PR DESCRIPTION

```console
$ ./bin/bgem install
ERROR: "bgem install" was called with no arguments
Usage: "bgem install [BUNDLED_GEM]"

$ ./bin/bgem install rake
Successfully installed rake-13.0.0
Parsing documentation for rake-13.0.0
Done installing documentation for rake after 0 seconds
1 gem installed

$ rake --version
rake, version 13.0.0

$ ./bin/bgem install rake2
`rake2` is not listed in Gemfile.lock.
