### PR TITLE
Add Ruby2.7 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6]
+        ruby: [2.4, 2.5, 2.6, 2.7]
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
       uses: actions/setup-ruby@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby ${{ matrix.ruby }}
-      uses: actions/setup-ruby@v1
+      uses: eregon/use-ruby-action@master
       with:
         ruby-version: ${{ matrix.ruby }}
     - name: Install gems

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ jobs:
   build:
     strategy:
       matrix:
-        ruby: [2.4.x, 2.5.x, 2.6.x]
+        ruby: [2.4, 2.5, 2.6]
         os: [ubuntu-latest, macos-latest]
 
     runs-on: ${{ matrix.os }}

--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,8 @@ source "https://rubygems.org"
 
 # Specify your gem's dependencies in bundled_gems.gemspec
 gemspec
+
+gem "minitest-reporters"
+gem "minitest"
+gem "rake"
+gem "rubocop-rails_config"

--- a/bundled_gems.gemspec
+++ b/bundled_gems.gemspec
@@ -33,9 +33,4 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "bundler"
   spec.add_dependency "thor"
-
-  spec.add_development_dependency "minitest-reporters"
-  spec.add_development_dependency "minitest"
-  spec.add_development_dependency "rake"
-  spec.add_development_dependency "rubocop-rails_config"
 end


### PR DESCRIPTION
- Use [eregon/use-ruby-action](https://github.com/eregon/use-ruby-action)
  - since official [actions/setup-ruby](https://github.com/actions/setup-ruby) doesn't support Ruby 2.7 yet.
- Move `add_development_dependency` to `Gemfile`