### PR TITLE
Use gem_name:gem_version install format

### DIFF
--- a/lib/bundled_gem/cli.rb
+++ b/lib/bundled_gem/cli.rb
@@ -15,7 +15,7 @@ module BundledGem
       bundled_gems.each do |bundled_gem|
         if reader.gem_listed?(bundled_gem)
           version = reader.get_version(bundled_gem)
-          command = "gem install #{bundled_gem} --version #{version}"
+          command = "gem install #{bundled_gem}:#{version}"
           IO.popen(command) do |f|
             while line = f.gets
               puts line


### PR DESCRIPTION
> Can't use --version with multiple gems. You can specify multiple gems with
> version requirements using `gem install 'my_gem:1.0.0' 'my_other_gem:~>2.0.0'`

cf. https://github.com/rubygems/rubygems/blob/3fea7ca51cc31cf46b0aeda703c4253686738960/lib/rubygems/commands/install_command.rb#L143-L150

## Blog

[How to install multiple gems with specific version | Toshimaru’s Blog](https://blog.toshima.ru/2021/02/14/install-multiple-gems-with-version.html)